### PR TITLE
Chapter 01 finite fields

### DIFF
--- a/src/field.rs
+++ b/src/field.rs
@@ -1,0 +1,66 @@
+#[derive(Debug, PartialEq, Eq)]
+struct FiniteField {
+    order: u32,
+}
+
+impl FiniteField {
+    // create a new finite field
+    // the order of the field must be a prime number
+    fn new(order: u32) -> Self {
+        if !is_prime(order) {
+            panic!("The order of the field must be a prime number");
+        }
+        Self { order }
+    }
+}
+
+// check if the value is prime
+fn is_prime(num: u32) -> bool {
+    if num == 2 {
+        return true;
+    }
+    if num < 2 || num % 2 == 0 {
+        return false;
+    }
+    let mut i = 3;
+    while i * i <= num {
+        if num % i == 0 {
+            return false;
+        }
+        i += 2;
+    }
+    true
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_is_prime() {
+        let values = vec![2, 11, 127, 10_453, 15_485_863];
+        for value in values {
+            assert_eq!(is_prime(value), true);
+        }
+    }
+
+    #[test]
+    fn test_is_not_prime() {
+        let values = vec![0, 1, 10, 378, 34_521, 98_765_432];
+        for value in values {
+            assert_eq!(is_prime(value), false);
+        }
+    }
+
+    #[test]
+    fn test_new() {
+        let field = FiniteField::new(2);
+        assert_eq!(field.order, 2);
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_new_panic() {
+        let _field = FiniteField::new(4);
+    }
+}

--- a/src/finite_field.rs
+++ b/src/finite_field.rs
@@ -1,11 +1,13 @@
+/// A finite field.
 #[derive(Debug, PartialEq, Eq)]
 struct FiniteField {
     order: u32,
 }
 
 impl FiniteField {
-    // create a new finite field
-    // the order of the field must be a prime number
+    /// Create a new finite field.  
+    /// Arguments:
+    /// * `order`: the order of the field must be a prime number.
     fn new(order: u32) -> Self {
         if !is_prime(order) {
             panic!("The order of the field must be a prime number");
@@ -14,7 +16,12 @@ impl FiniteField {
     }
 }
 
-// check if the value is prime
+impl std::fmt::Display for FiniteField {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(f, "Finite field of order {}", self.order)
+    }
+}
+
 fn is_prime(num: u32) -> bool {
     if num == 2 {
         return true;
@@ -62,5 +69,35 @@ mod tests {
     #[should_panic]
     fn test_new_panic() {
         let _field = FiniteField::new(4);
+    }
+
+    #[test]
+    fn test_new_panic_message() {
+        let result = std::panic::catch_unwind(|| FiniteField::new(4));
+        assert!(result.is_err());
+        assert_eq!(
+            result.unwrap_err().downcast_ref::<&str>(),
+            Some(&"The order of the field must be a prime number")
+        );
+    }
+
+    #[test]
+    fn test_eq() {
+        let field1 = FiniteField::new(2);
+        let field2 = FiniteField::new(2);
+        assert_eq!(field1, field2);
+    }
+
+    #[test]
+    fn test_ne() {
+        let field1 = FiniteField::new(2);
+        let field2 = FiniteField::new(3);
+        assert_ne!(field1, field2);
+    }
+
+    #[test]
+    fn test_display() {
+        let field = FiniteField::new(2);
+        assert_eq!(format!("{}", field), "Finite field of order 2");
     }
 }

--- a/src/finite_field.rs
+++ b/src/finite_field.rs
@@ -1,6 +1,6 @@
 /// A finite field.
-#[derive(Debug, PartialEq, Eq)]
-struct FiniteField {
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+pub struct FiniteField {
     order: u32,
 }
 
@@ -8,11 +8,16 @@ impl FiniteField {
     /// Create a new finite field.  
     /// Arguments:
     /// * `order`: the order of the field must be a prime number.
-    fn new(order: u32) -> Self {
+    pub fn new(order: u32) -> Self {
         if !is_prime(order) {
             panic!("The order of the field must be a prime number");
         }
         Self { order }
+    }
+
+    /// Get the order of the field.
+    pub fn order(&self) -> u32 {
+        self.order
     }
 }
 

--- a/src/finite_field.rs
+++ b/src/finite_field.rs
@@ -23,10 +23,7 @@ impl std::fmt::Display for FiniteField {
 }
 
 fn is_prime(num: u32) -> bool {
-    if num == 2 {
-        return true;
-    }
-    if num < 2 || num % 2 == 0 {
+    if num < 2 || (num > 2 && num % 2 == 0) {
         return false;
     }
     let mut i = 3;

--- a/src/finite_field_element.rs
+++ b/src/finite_field_element.rs
@@ -15,6 +15,13 @@ impl FFElement {
         }
         Self { num, field }
     }
+
+    pub fn pow(&self, exponent: u32) -> Self {
+        match self.num.checked_pow(exponent) {
+            Some(num) => Self::new(num.rem_euclid(self.field.order()), self.field),
+            None => panic!("Overflow error"),
+        }
+    }
 }
 
 impl std::fmt::Display for FFElement {
@@ -74,26 +81,6 @@ impl std::ops::Mul for FFElement {
             }
             None => panic!("Overflow error"),
         }
-    }
-}
-
-impl FFElement {
-    /// Computes the power of an element in a finite field
-    pub fn pow(self, exp: u32) -> Self {
-        // Raises self to the power of exp, using exponentiation by squaring.
-        let mut base = self;
-        let mut result = Self::new(1, self.field);
-        let mut exp = exp;
-
-        while exp > 0 {
-            if exp & 1 == 1 {
-                result = result * base;
-            }
-            exp >>= 1;
-            base = base * base;
-        }
-
-        result
     }
 }
 

--- a/src/finite_field_element.rs
+++ b/src/finite_field_element.rs
@@ -1,0 +1,54 @@
+use crate::finite_field::FiniteField;
+
+/// A finite field element.
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+pub struct FFElement {
+    num: u32,
+    field: FiniteField,
+}
+
+impl FFElement {
+    pub fn new(num: u32, field: FiniteField) -> Self {
+        // check that num is between 0 and order-1 inclusive
+        if num >= field.order() {
+            panic!("num must be between 0 and order-1 inclusive");
+        }
+        Self { num, field }
+    }
+}
+
+impl std::fmt::Display for FFElement {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(f, "FieldElement_{}({})", self.field.order(), self.num)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_eq() {
+        let field = FiniteField::new(13);
+        let a = FFElement::new(7, field);
+        let b = FFElement::new(6, field);
+        assert_eq!(a == b, false);
+        assert_eq!(a == a, true);
+    }
+
+    #[test]
+    fn test_ne() {
+        let field = FiniteField::new(13);
+        let a = FFElement::new(7, field);
+        let b = FFElement::new(6, field);
+        assert_eq!(a != b, true);
+        assert_eq!(a != a, false);
+    }
+
+    #[test]
+    fn test_display() {
+        let field = FiniteField::new(13);
+        let a = FFElement::new(7, field);
+        assert_eq!(format!("{}", a), "FieldElement_13(7)");
+    }
+}

--- a/src/finite_field_element.rs
+++ b/src/finite_field_element.rs
@@ -23,6 +23,24 @@ impl std::fmt::Display for FFElement {
     }
 }
 
+impl std::ops::Add for FFElement {
+    type Output = Self;
+
+    fn add(self, other: Self) -> Self {
+        if self.field != other.field {
+            panic!("Cannot add two numbers in different Fields");
+        }
+
+        match self.num.checked_add(other.num) {
+            Some(num) => {
+                let mod_sum = num.rem_euclid(self.field.order());
+                Self::new(mod_sum, self.field)
+            }
+            None => panic!("Overflow error"),
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -50,5 +68,18 @@ mod tests {
         let field = FiniteField::new(13);
         let a = FFElement::new(7, field);
         assert_eq!(format!("{}", a), "FieldElement_13(7)");
+    }
+
+    #[test]
+    fn test_add() {
+        let field = FiniteField::new(31);
+        let a = FFElement::new(2, field);
+        let b = FFElement::new(15, field);
+        let c = FFElement::new(17, field);
+        assert_eq!(a + b == c, true);
+        let a = FFElement::new(17, field);
+        let b = FFElement::new(21, field);
+        let c = FFElement::new(7, field);
+        assert_eq!(a + b == c, true);
     }
 }

--- a/src/finite_field_element.rs
+++ b/src/finite_field_element.rs
@@ -41,6 +41,24 @@ impl std::ops::Add for FFElement {
     }
 }
 
+impl std::ops::Sub for FFElement {
+    type Output = Self;
+
+    fn sub(self, other: Self) -> Self {
+        if self.field != other.field {
+            panic!("Cannot subtract two numbers in different Fields");
+        }
+
+        // property of sums and differences in modular arithmetic
+        // (a - b) mod n = [(a mod n) - (b mod n)] mod n
+        let n = self.field.order();
+        let a = self.num.rem_euclid(n);
+        let b = other.num.rem_euclid(n);
+
+        Self::new((a + n - b).rem_euclid(n), self.field)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -81,5 +99,18 @@ mod tests {
         let b = FFElement::new(21, field);
         let c = FFElement::new(7, field);
         assert_eq!(a + b == c, true);
+    }
+
+    #[test]
+    fn test_sub() {
+        let field = FiniteField::new(31);
+        let a = FFElement::new(29, field);
+        let b = FFElement::new(4, field);
+        let c = FFElement::new(25, field);
+        assert_eq!(a - b == c, true);
+        let a = FFElement::new(15, field);
+        let b = FFElement::new(30, field);
+        let c = FFElement::new(16, field);
+        assert_eq!(a - b == c, true);
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,1 +1,2 @@
-mod finite_field;
+pub mod finite_field;
+pub mod finite_field_element;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,1 +1,1 @@
-mod field;
+mod finite_field;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,14 +1,1 @@
-pub fn add(left: usize, right: usize) -> usize {
-    left + right
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn it_works() {
-        let result = add(2, 2);
-        assert_eq!(result, 4);
-    }
-}
+mod field;


### PR DESCRIPTION
# Finite Field Definition

A finite field is defined as a finite set of numbers and two operations `+` (addition) and `⋅` (multiplication) that satisfy the following:

1. If `a` and `b` are in the set, `a + b` and `a ⋅ b` are in the set. We call this property _closed_.
2. `0` exists and has the property `a + 0 = a`. We call this the _additive identity_.
3. `1` exists and has the property `a ⋅ 1 = a`. We call this the _multiplicative identity_.
4. If a is in the set, `–a` is in the set, which is defined as the value that makes `a + (–a) = 0`. This is what we call the _additive inverse_.
5. If a is in the set and is not `0`, `a^–1` is in the set, which is defined as the value that makes `a ⋅ a^–1 = 1`. This is what we call the _multiplicative inverse_.

- because the set is finite, we can designate a number `p`, which is how big the set is. This is what we call the _order_ of the set.
    - fields must have an order that is a power of a prime
    - the finite fields whose order is prime are the ones we’re interested in
- we have to define addition and multiplication in a way that ensures the results stay in the set.
- and 1 are in the set.
- if a is in the set, `–a` is in the set
- if a is in the set, `a^–1` is in the set

We want to represent each finite field element.

We can define addition on the finite set using modulo arithmetic.

`n^(p–1)` is always 1 for every p that is prime and every n > 0. 

Fermat’s little theorem. `n^(p–1)%p = 1` where `p` is prime.