### PR TITLE
Chapter 02 elliptic curves

### DIFF
--- a/src/elliptic_curve.rs
+++ b/src/elliptic_curve.rs
@@ -2,9 +2,9 @@
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
 pub struct EllipticCurve {
     /// The coefficient of the x term
-    a: u32,
+    a: i32,
     /// The constant term
-    b: u32,
+    b: i32,
 }
 
 impl EllipticCurve {
@@ -12,8 +12,16 @@ impl EllipticCurve {
     /// Arguments:
     /// * `a`: the coefficient of the x term
     /// * `b`: the constant term
-    pub fn new(a: u32, b: u32) -> Self {
+    pub const fn new(a: i32, b: i32) -> Self {
         Self { a, b }
+    }
+
+    pub fn a(&self) -> i32 {
+        self.a
+    }
+
+    pub fn b(&self) -> i32 {
+        self.b
     }
 }
 

--- a/src/elliptic_curve.rs
+++ b/src/elliptic_curve.rs
@@ -1,0 +1,56 @@
+/// Elliptic curve
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+pub struct EllipticCurve {
+    /// The coefficient of the x term
+    a: u32,
+    /// The constant term
+    b: u32,
+}
+
+impl EllipticCurve {
+    /// Create a new elliptic curve.
+    /// Arguments:
+    /// * `a`: the coefficient of the x term
+    /// * `b`: the constant term
+    pub fn new(a: u32, b: u32) -> Self {
+        Self { a, b }
+    }
+}
+
+impl std::fmt::Display for EllipticCurve {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(f, "y^2 = x^3 + {}x + {}", self.a, self.b)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_new() {
+        let curve = EllipticCurve::new(1, 2);
+        assert_eq!(curve.a, 1);
+        assert_eq!(curve.b, 2);
+    }
+
+    #[test]
+    fn test_fmt() {
+        let curve = EllipticCurve::new(1, 2);
+        assert_eq!(format!("{}", curve), "y^2 = x^3 + 1x + 2");
+    }
+
+    #[test]
+    fn test_eq() {
+        let curve1 = EllipticCurve::new(1, 2);
+        let curve2 = EllipticCurve::new(1, 2);
+        assert_eq!(curve1, curve2);
+    }
+
+    #[test]
+    fn test_ne() {
+        let curve1 = EllipticCurve::new(1, 2);
+        let curve2 = EllipticCurve::new(2, 1);
+        assert_ne!(curve1, curve2);
+    }
+}

--- a/src/elliptic_curve_point.rs
+++ b/src/elliptic_curve_point.rs
@@ -1,0 +1,123 @@
+use crate::elliptic_curve::EllipticCurve;
+
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+pub struct ECPoint {
+    x: Option<i32>,
+    y: Option<i32>,
+    curve: EllipticCurve,
+}
+
+impl ECPoint {
+    pub fn new(x: i32, y: i32, curve: EllipticCurve) -> Self {
+        let a = curve.a();
+        let b = curve.b();
+
+        let y2 = y.pow(2);
+        let x3 = x.pow(3);
+
+        if y2 != x3 + a * x + b {
+            panic!("({}, {}) is not on the curve", x, y);
+        }
+
+        Self {
+            x: Some(x),
+            y: Some(y),
+            curve,
+        }
+    }
+
+    pub fn infinity(curve: EllipticCurve) -> Self {
+        Self {
+            x: None,
+            y: None,
+            curve,
+        }
+    }
+
+    pub fn is_infinity(&self) -> bool {
+        self.x.is_none() && self.y.is_none()
+    }
+
+    pub fn x(&self) -> Option<i32> {
+        self.x
+    }
+
+    pub fn y(&self) -> Option<i32> {
+        self.y
+    }
+
+    pub fn curve(&self) -> EllipticCurve {
+        self.curve
+    }
+}
+
+impl std::fmt::Display for ECPoint {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        if self.is_infinity() {
+            write!(f, "Point(infinity)")
+        } else {
+            write!(f, "Point({}, {})", self.x.unwrap(), self.y.unwrap())
+        }
+    }
+}
+
+// test module
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const CURVE: EllipticCurve = EllipticCurve::new(5, 7);
+
+    #[cfg(test)]
+    mod curve_point_tests {
+        use super::*;
+        // Determine which of these points are on the curve y2 = x3 + 5x + 7:
+        // Cases:
+        //      - true: (–1,–1), (18,77)
+        //      - false: (2,4), (5,7)
+
+        #[test]
+        fn test_point_on_curve_1() {
+            ECPoint::new(-1, -1, CURVE);
+        }
+
+        #[test]
+        fn test_point_on_curve_2() {
+            ECPoint::new(18, 77, CURVE);
+        }
+
+        #[test]
+        #[should_panic]
+        fn test_point_not_on_curve_1() {
+            ECPoint::new(2, 4, CURVE);
+        }
+
+        #[test]
+        #[should_panic]
+        fn test_point_not_on_curve_2() {
+            ECPoint::new(5, 7, CURVE);
+        }
+    }
+
+    // Determine which of these points are equal:
+    #[cfg(test)]
+    mod point_equality_tests {
+        use super::*;
+
+        #[test]
+        fn test_point_equality() {
+            let a = ECPoint::new(3, -7, CURVE);
+            let b = ECPoint::new(18, 77, CURVE);
+            assert_eq!(a == b, false);
+            assert_eq!(a == a, true);
+        }
+
+        #[test]
+        fn test_point_inequality() {
+            let a = ECPoint::new(3, -7, CURVE);
+            let b = ECPoint::new(18, 77, CURVE);
+            assert_eq!(a != b, true);
+            assert_eq!(a != a, false);
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
 pub mod elliptic_curve;
+pub mod elliptic_curve_point;
 pub mod finite_field;
 pub mod finite_field_element;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,2 +1,3 @@
+pub mod elliptic_curve;
 pub mod finite_field;
 pub mod finite_field_element;


### PR DESCRIPTION
# Elliptic Curves

Equation: `y^2 =x^3 + ax + b`

The elliptic curve used in Bitcoin is called `secp256k1` and it uses this particular equation: `y2 = x3 + 7`. The curve is defined by the constants `a = 0`, `b = 7`.

We are not interested in the curve itself, but specific points on the curve.

We can define the curve with just the two numbers `a` and `b`.

## Code Point Addition
To code point addition, we’re going to split it up into three steps:
1. Where the points are in a vertical line or using the identity point
    - `x1 == x2 && y1 != y2`
2. Where the points are not in a vertical line, but are different
    - `x1 != x2`
3. Where the two points are the same
    - `x1 == x2 && y1 == y2`


## P1 == I || P2 == I
If either point is the point at infinity, we return the other point.

## x1 ≠ x2
When we have points where the x’s differ, we can add using a fairly simple formula. 
- We’ll first find the slope created by the two points:
    - `s = (y2 - y1)/(x2 - x1)`  
- We can use the slope to calculate x3. Once we know x3, we can
calculate y3. 
    - `x3 = s2 - x1 - x2`
    - `y3 = s(x1 - x3) - y1`

## x1 == x2 && y1 != y2
When the two points are additive inverses (that is, they have the same x but a different y, causing a vertical line). This should return the point at infinity.

## P1 = P2
We have to calculate the line that’s tangent to the curve at P1 and find the point at which the line intersects the curve. 
- We’ll find the slope of the tangent point: 
    - s = (3x1^2 + a)/(2y1)
- The rest of the formula:
    - `x3 = s^2 - 2x1`
    - `y3 = s(x1 - x3) - y1`

## One More Exception
This can only happen if P1 = P2 and the y coordinate is 0, in which case the slope calculation will end up with a 0 in the denominator. 
If the two points are equal and the y coordinate is 0, we return the point at infinity.