### PR TITLE
Chapter 04 serialization

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,3 +14,7 @@ rand = "0.8.5"
 num = "0.4.0"
 sha2 = "0.10.6"
 rfc6979 = "0.4.0"
+
+
+[dev-dependencies]
+hex = "0.4.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ rand = "0.8.5"
 num = "0.4.0"
 sha2 = "0.10.6"
 rfc6979 = "0.4.0"
-
+ripemd = "0.1.3"
 
 [dev-dependencies]
 hex = "0.4.3"

--- a/src/elliptic_curve/element.rs
+++ b/src/elliptic_curve/element.rs
@@ -35,6 +35,13 @@ impl FFElement {
         Self::new(&num, &self.field)
     }
 
+    pub fn sqrt(&self) -> Self {
+        let p = self.field.order();
+        let exp = (p + BigUint::from(1u32)) / BigUint::from(4u32);
+        let num = self.num.modpow(&exp, &p);
+        Self::new(&num, &self.field)
+    }
+
     pub fn num(&self) -> &BigUint {
         &self.num
     }

--- a/src/elliptic_curve/signature.rs
+++ b/src/elliptic_curve/signature.rs
@@ -25,8 +25,88 @@ impl Signature {
     }
 }
 
+impl Signature {
+    /// DER encode the signature
+    pub fn der(&self) -> Vec<u8> {
+        let mut rbin = self.r.to_bytes_be();
+
+        // remove leading zeros
+        while !rbin.is_empty() && rbin[0] == 0 {
+            rbin.remove(0);
+        }
+
+        // if rbin has a high bit, add a \x00
+        let rbin = if rbin.is_empty() || rbin[0] & 0x80 == 0x80 {
+            let mut rbin = rbin.to_vec();
+            rbin.insert(0, 0);
+            rbin
+        } else {
+            rbin.to_vec()
+        };
+
+        let mut result = vec![2, rbin.len() as u8];
+        result.extend_from_slice(&rbin);
+
+        let mut sbin = self.s.to_bytes_be();
+
+        // remove leading zeross
+        while !sbin.is_empty() && sbin[0] == 0 {
+            sbin.remove(0);
+        }
+
+        // if sbin has a high bit, add a \x00
+        let sbin = if sbin.is_empty() || sbin[0] & 0x80 == 0x80 {
+            let mut sbin = sbin.to_vec();
+            sbin.insert(0, 0);
+            sbin
+        } else {
+            sbin.to_vec()
+        };
+
+        result.extend_from_slice(&[2, sbin.len() as u8]);
+        result.extend_from_slice(&sbin);
+
+        let mut der = vec![0x30, result.len() as u8];
+        der.extend_from_slice(&result);
+
+        der
+    }
+}
+
 impl fmt::Display for Signature {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "Signature({:x},{:x})", self.r, self.s)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use num::Num;
+
+    #[test]
+    fn test_der() {
+        let r = BigUint::from_str_radix(
+            "37206a0610995c58074999cb9767b87af4c4978db68c06e8e6e81d282047a7c6",
+            16,
+        )
+        .unwrap();
+
+        let s = BigUint::from_str_radix(
+            "8ca63759c1157ebeaec0d03cecca119fc9a75bf8e6d0fa65c841c8e2738cdaec",
+            16,
+        )
+        .unwrap();
+
+        let sig = Signature::new(&r, &s);
+
+        assert_eq!(
+            sig.der(),
+            hex::decode(
+                "3045022037206a0610995c58074999cb9767b87af4c4978db68c06e8e6e81d282047a7c6\
+                0221008ca63759c1157ebeaec0d03cecca119fc9a75bf8e6d0fa65c841c8e2738cdaec"
+            )
+            .unwrap()
+        );
     }
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,1 +1,2 @@
 pub mod biguint_primality_checker;
+pub mod encode_base58;

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,2 +1,3 @@
 pub mod biguint_primality_checker;
 pub mod encode_base58;
+pub mod hash256;

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,3 +1,4 @@
 pub mod biguint_primality_checker;
 pub mod encode_base58;
+pub mod hash160;
 pub mod hash256;

--- a/src/utils/encode_base58.rs
+++ b/src/utils/encode_base58.rs
@@ -1,0 +1,64 @@
+use num::{BigUint, Integer, ToPrimitive, Zero};
+
+const BASE58_ALPHABET: &str = "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz";
+
+pub fn encode_base58(bytes: &[u8]) -> String {
+    let mut result = String::new();
+    let mut leading_zeros = 0;
+    // The purpose of this loop is to determine how many of the bytes at the
+    // front are 0 bytes. We want to add them back at the end.
+    for byte in bytes {
+        if *byte == 0 {
+            leading_zeros += 1;
+        } else {
+            break;
+        }
+    }
+    let mut num = BigUint::from_bytes_be(bytes);
+    // This is the loop that figures out what Base58 digit to use.
+    while num > BigUint::zero() {
+        let (div, rem) = num.div_rem(&BigUint::from(58u8));
+        num = div;
+        result.push(
+            BASE58_ALPHABET
+                .chars()
+                .nth(rem.to_u8().unwrap() as usize)
+                .unwrap(),
+        );
+    }
+    for _ in 0..leading_zeros {
+        result.push(BASE58_ALPHABET.chars().nth(0).unwrap());
+    }
+    result.chars().rev().collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use num::Num;
+
+    use super::*;
+
+    #[test]
+    fn test_encode_base58() {
+        let values = vec![
+            (
+                "7c076ff316692a3d7eb3c3bb0f8b1488cf72e1afcd929e29307032997a838a3d",
+                "9MA8fRQrT4u8Zj8ZRd6MAiiyaxb2Y1CMpvVkHQu5hVM6",
+            ),
+            (
+                "eff69ef2b1bd93a66ed5219add4fb51e11a840f404876325a1e8ffe0529a2c",
+                "4fE3H2E6XMp4SsxtwinF7w9a34ooUrwWe4WsW1458Pd",
+            ),
+            (
+                "c7207fee197d27c618aea621406f6bf5ef6fca38681d82b2f06fddbdce6feab6",
+                "EQJsjkd6JaGwxrjEhfeqPenqHwrBmPQZjJGNSCHBkcF7",
+            ),
+        ];
+
+        for (value, expected) in values {
+            let value = BigUint::from_str_radix(value, 16).unwrap().to_bytes_be();
+            let result = encode_base58(&value);
+            assert_eq!(result, expected);
+        }
+    }
+}

--- a/src/utils/hash160.rs
+++ b/src/utils/hash160.rs
@@ -1,0 +1,26 @@
+use ripemd::{Digest, Ripemd160};
+use sha2::Sha256;
+
+/// Two rounds of sha256 and ripemd160
+pub fn hash160(bytes: &[u8]) -> [u8; 20] {
+    let mut hasher = Ripemd160::new();
+    hasher.update(Sha256::digest(bytes));
+    let result = hasher.finalize();
+    let mut hash: [u8; 20] = [0; 20];
+    hash.copy_from_slice(&result);
+    hash
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn test_hash160() {
+        let value = "7c076ff316692a3d7eb3c3bb0f8b1488cf72e1afcd929e29307032997a838a3d";
+        let value: Vec<u8> = hex::decode(value).unwrap();
+        let result = super::hash160(&value);
+        assert_eq!(
+            hex::encode(result),
+            "9cb1656f99c65ce3be73ddef9041b9bbeaa42369"
+        );
+    }
+}

--- a/src/utils/hash256.rs
+++ b/src/utils/hash256.rs
@@ -1,0 +1,25 @@
+use sha2::{Digest, Sha256};
+
+/// Two rounds of sha256
+pub fn hash256(bytes: &[u8]) -> [u8; 32] {
+    let hash = Sha256::digest(&Sha256::digest(bytes));
+    let mut result: [u8; 32] = [0; 32];
+    result.copy_from_slice(&hash);
+    result
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_hash256() {
+        let value = "7c076ff316692a3d7eb3c3bb0f8b1488cf72e1afcd929e29307032997a838a3d";
+        let value: Vec<u8> = hex::decode(value).unwrap();
+        let result = hash256(&value);
+        assert_eq!(
+            hex::encode(result),
+            "ea5ea40fc1b5dd6002295bf06cae70663742a5d12f5760c27f4f9339aa28e442"
+        );
+    }
+}


### PR DESCRIPTION
# Serialization

There are two forms of SEC format that we need to be concerned with: uncompressed and compressed. 

## Uncompressed SEC Format
Here is how the uncompressed SEC format for a given point `P = (x,y)` is generated:
1. Start with the prefix byte, which is `0x04`.
2. Next, append the `x` coordinate in 32 bytes as a big-endian integer.
3. Next, append the `y` coordinate in 32 bytes as a big-endian integer.

## Compressed SEC Format
Here is the serialization of the compressed SEC format for a given point `P = (x,y)`:
1. Start with the prefix byte. If `y` is even, it’s `0x02`; otherwise, it’s `0x03`.
2. Next, append the `x` coordinate in 32 bytes as a big-endian integer.

Calculate `y` given the `x` coordinate requires us to calculate a square root in a finite field: 

if `w2 = v` and `p % 4 = 3`, `w = v(p+1)/4`

## DER Signatures

Distinguished Encoding Rules (DER)

DER format is defined like this:
1. Start with the `0x30` byte.
2. Encode the length of the rest of the signature (usually `0x44` or `0x45`) and append.
3. Append the marker byte, `0x02`.
4. Encode `r` as a big-endian integer, but prepend it with the 0x00 byte if `r`’s first byte ≥ `0x80`. Prepend the resulting length to `r`. Add this to the result.
5. Append the marker byte, `0x02`.
6. Encode `s` as a big-endian integer, but prepend with the `0x00` byte if s’s first byte ≥ `0x80`. Prepend the resulting length to `s`. Add this to the result.

The rules for #4 and #6 with the first byte starting with something greater than or equal to `0x80` are because DER is a general encoding and allows for negative numbers to be encoded. The first bit being 1 means that the number is negative. All numbers in an ECDSA signature are positive, so we have to prepend with `0x00` if the first bit is zero, which is equivalent to first byte ≥ `0x80`.

## Base58

`BASE58_ALPHABET = '123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz'`

## Address format
The 264 bits from compressed SEC format are still a bit too long, not to mention a bit less secure. To both shorten the address and increase security, we can use the ripemd160 hash.

By not using the SEC format directly, we can go from 33 bytes to 20 bytes, shortening the address significantly. Here is how a Bitcoin address is created:

1. For mainnet addresses, start with the prefix 0x00, for testnet `0x6f`.
2. Take the SEC format (compressed or uncompressed) and do a sha256 operation followed by the ripemd160 hash operation, the combination of which is called a hash160 operation.
3. Combine the prefix from #1 and resulting hash from #2.
4. Do a hash256 of the result from #3 and get the first 4 bytes. (checksum)
5. Take the combination of #3 and #4 and encode it in Base58.

## WIF Format
Wallet Import Format is a serialization of the private key that’s meant to be human-readable. WIF uses the same Base58 encoding that addresses use.

Here is how the WIF format is created:
1. For mainnet private keys, start with the prefix `0x80`, for testnet `0xef`. 
2. Encode the secret in 32-byte big-endian.
3. If the SEC format used for the public key address was compressed, add a suffix of `0x01`.
4. Combine the prefix from #1, serialized secret from #2, and suffix from #3.
5. Do a hash256 of the result from #4 and get the first 4 bytes.
6. Take the combination of #4 and #5 and encode it in Base58.